### PR TITLE
fix: remove completionHandler from finish

### DIFF
--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -285,14 +285,6 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_METHOD(onFinishRemoteNotification:(NSString *)notificationId fetchResult:(UIBackgroundFetchResult)result) {
-  RNCRemoteNotificationCallback completionHandler = self.remoteNotificationCallbacks[notificationId];
-  if (!completionHandler) {
-    RCTLogError(@"There is no completion handler with notification id: %@", notificationId);
-    return;
-  }
-  if ([[[UIDevice currentDevice] systemVersion] floatValue] < 14.0) {
-    completionHandler(result);
-  }
   [self.remoteNotificationCallbacks removeObjectForKey:notificationId];
 }
 


### PR DESCRIPTION
Copied changes from this pull request of the official repo: https://github.com/react-native-push-notification-ios/push-notification-ios/pull/241